### PR TITLE
Update airmail-beta to 3.7.0,552,394

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,8 +1,8 @@
 cask 'airmail-beta' do
-  version '3.7.0,393'
+  version '3.7.0,549,393'
   sha256 '47d4ecae81f27c1fca58bd96c196a91f12ef262f2c7b47ad19750e6cd37ee26d'
 
-  url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"
+  url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma.after_comma}?format=zip&"
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04'
   name 'Airmail'
   homepage 'https://rink.hockeyapp.net/apps/84be85c3331ee1d222fd7f0b59e41b04'

--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,6 +1,6 @@
 cask 'airmail-beta' do
-  version '3.7.0,549,393'
-  sha256 '47d4ecae81f27c1fca58bd96c196a91f12ef262f2c7b47ad19750e6cd37ee26d'
+  version '3.7.0,552,394'
+  sha256 '71bc6f43a5ffd8ec24276550b4e7239cce2c97ea6cc57ef47f9fd5e6086a65d2'
 
   url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma.after_comma}?format=zip&"
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.