### PR TITLE
Fix airmail beta cask

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -2,11 +2,10 @@ cask 'airmail-beta' do
   version '3.7.0,393'
   sha256 '47d4ecae81f27c1fca58bd96c196a91f12ef262f2c7b47ad19750e6cd37ee26d'
 
-  # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04'
   name 'Airmail'
-  homepage 'https://airmailapp.com/beta/'
+  homepage 'https://rink.hockeyapp.net/apps/84be85c3331ee1d222fd7f0b59e41b04'
 
   app 'Airmail Beta.app'
 

--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,5 +1,5 @@
 cask 'airmail-beta' do
-  version '3.7.0.704,549'
+  version '3.7.0,393'
   sha256 '47d4ecae81f27c1fca58bd96c196a91f12ef262f2c7b47ad19750e6cd37ee26d'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.