### PR TITLE
Update airmail-beta to 4.0,584,450

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,11 +1,12 @@
 cask 'airmail-beta' do
-  version '3.7.0,552,394'
-  sha256 '71bc6f43a5ffd8ec24276550b4e7239cce2c97ea6cc57ef47f9fd5e6086a65d2'
+  version '4.0,450'
+  sha256 '09f6728d73531b98150f888f913dffed5d31dbc01ec93bb9d9ab29ea96d5457f'
 
-  url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma.after_comma}?format=zip&"
+  # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
+  url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04'
   name 'Airmail'
-  homepage 'https://rink.hockeyapp.net/apps/84be85c3331ee1d222fd7f0b59e41b04'
+  homepage 'https://airmailapp.com/beta/'
 
   app 'Airmail Beta.app'
 

--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,9 +1,9 @@
 cask 'airmail-beta' do
-  version '4.0,450'
+  version '4.0,584,450'
   sha256 '09f6728d73531b98150f888f913dffed5d31dbc01ec93bb9d9ab29ea96d5457f'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
-  url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"
+  url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma.after_comma}?format=zip&"
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04'
   name 'Airmail'
   homepage 'https://airmailapp.com/beta/'

--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,10 +1,9 @@
 cask 'airmail-beta' do
-  version '4.0,584,450'
-  mctoken '319416917c51df46dc3735596313a880fa441c26'
+  version '4.0,584,450:319416917c51df46dc3735596313a880fa441c26'
   sha256 '09f6728d73531b98150f888f913dffed5d31dbc01ec93bb9d9ab29ea96d5457f'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
-  url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma.after_comma}?format=zip&mctoken=#{mctoken}"
+  url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma.after_comma.before_colon}?format=zip&mctoken=#{version.after_comma.after_comma.after_colon}"
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04'
   name 'Airmail'
   homepage 'https://airmailapp.com/beta/'

--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,9 +1,10 @@
 cask 'airmail-beta' do
   version '4.0,584,450'
+  mctoken '319416917c51df46dc3735596313a880fa441c26'
   sha256 '09f6728d73531b98150f888f913dffed5d31dbc01ec93bb9d9ab29ea96d5457f'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
-  url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma.after_comma}?format=zip&"
+  url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma.after_comma}?format=zip&mctoken=#{mctoken}"
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04'
   name 'Airmail'
   homepage 'https://airmailapp.com/beta/'


### PR DESCRIPTION
Homebrew/homebrew-cask-versions has been reintroduced. Follow this.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
