### PR TITLE
Add melonbooksviewer

### DIFF
--- a/Casks/melonbooksviewer.rb
+++ b/Casks/melonbooksviewer.rb
@@ -1,0 +1,14 @@
+cask "melonbooksviewer" do
+  version "1.2.0"
+  sha256 :no_check
+
+  url "https://www.melonbooks.co.jp/user_data/packages/default/app/melonbooks-viewer-mac.zip"
+  name "Melonbooks Viewer"
+  name "メロンブックス 電子書籍"
+  desc "Ebook viewer"
+  homepage "https://www.melonbooks.co.jp/ebook/list.php?category_id=77"
+
+  pkg "installer-signed-melon.pkg"
+
+  uninstall pkgutil: "jp.co.melonbooks.viewer"
+end


### PR DESCRIPTION
back to enable. in japan, ignore geoblocked.

After making all changes to a cask, verify:

- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
